### PR TITLE
Remove GNU references, as appropriate

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 baseurl = "https://chicagolug.org/"
-title = "The Chicago GNU/Linux User Group"
+title = "The Chicago Linux User Group"
 subtitle = "ChicagoLUG"
 theme = "hugo-universal-theme"
 languageCode = "en-us"
@@ -105,7 +105,7 @@ paginate = 10
     enable = true
     icon = "fa fa-linux"
     title = "Welcome!"
-    subtitle = "The Chicago GNU/Linux User Group is a community of GNU/Linux and Free software developers, enthusiasts and system administrators who live in and around Chicago, Illinois. If you're curious about Linux and Free/Libre and Open-Source software, consider joining us."
+    subtitle = "The Chicago Linux User Group is a community of Linux and Free software developers, enthusiasts and system administrators who live in and around Chicago, Illinois. If you're curious about Linux and Free/Libre and Open-Source software, consider joining us."
     link_url = "pages/about/"
     link_text = "Learn More"
 

--- a/content/about.md
+++ b/content/about.md
@@ -2,7 +2,7 @@
 title = "About ChicagoLUG"
 subtitle = "About ChicagoLUG"
 date = "2016-11-25T14:31:53-06:00"
-description = "Information about the Chicago GNU/Linux User Group."
+description = "Information about the Chicago Linux User Group."
 slug = "pages/about"
 tags = [ "about" ] 
 type = "page"

--- a/content/contact.md
+++ b/content/contact.md
@@ -2,7 +2,7 @@
 title = "Get in touch with ChicagoLUG"
 subtitle = "Contacting ChicagoLUG"
 date = "2016-11-25T14:31:53-06:00"
-description = "Contact information for the Chicago GNU/Linux User Group."
+description = "Contact information for the Chicago Linux User Group."
 slug = "pages/contact"
 tags = [ "contact" ]
 type = "page"

--- a/content/meetings/2013-01-19.md
+++ b/content/meetings/2013-01-19.md
@@ -25,5 +25,5 @@ The event will be at Chicago's Pumping Station: One, located at 3519
 North Elston in Chicago. Talks and speaking order are subject to change.
 
 People of all ability levels are welcome to join us, learn more
-GNU/Linux, and contribute. If you have any questions, feel free to be in
+Linux, and contribute. If you have any questions, feel free to be in
 touch via our mailing list or any of our social media channels.

--- a/content/meetings/2013-02-16.md
+++ b/content/meetings/2013-02-16.md
@@ -34,5 +34,5 @@ at 3519 North Elston in Chicago. Talks and speaking order are subject to
 change.
 
 People of all ability levels are welcome to join us, learn more
-GNU/Linux, and contribute. If you have any questions, feel free to be in
+Linux, and contribute. If you have any questions, feel free to be in
 touch via our mailing list or any of our social media channels.

--- a/content/meetings/2013-03-23.md
+++ b/content/meetings/2013-03-23.md
@@ -16,5 +16,5 @@ best practices concerning authentication and security. Part of his focus
 will be on what can go wrong if these tools are used improperly.
 
 People of all ability levels are welcome to join us, learn more
-GNU/Linux, and contribute. If you have any questions, feel free to be in
+Linux, and contribute. If you have any questions, feel free to be in
 touch via our mailing list or any of our social media channels.

--- a/content/meetings/2015-08-15.md
+++ b/content/meetings/2015-08-15.md
@@ -2,7 +2,7 @@
 title = "August 2015 Meeting of the ChicagoLUG"
 subtitle = "BarCamp, The annual Chicago unconference"
 date = "2015-08-15T14:00:00-06:00"
-description = "Learn about Juju from Canonical's server community lead, Jorge Castro, and learn about various components of Amazon Web Services from GNU/Linux admin, Peter Baumgarten."
+description = "Learn about Juju from Canonical's server community lead, Jorge Castro, and learn about various components of Amazon Web Services from Linux admin, Peter Baumgarten."
 slug = "2015-08-15"
 tags = [ "Jorge Castro", "Peter Baumgarten", "Juju", "AWS" ] 
 type = "meetings"

--- a/content/meetings/2016-04-16.md
+++ b/content/meetings/2016-04-16.md
@@ -12,7 +12,7 @@ author = "ChicagoLUG"
 
 <img src="/img/meetings/eff-tux.jpg" alt="EFF Tux - Image attribution: Larry Ewing, Simon Budig, Anja Gerwinski, and the Electronic Frontier Foundation" style="float:right;">
 
-On Saturday, April 16th, members of the Chicago GNU/Linux User Group
+On Saturday, April 16th, members of the Chicago Linux User Group
 along with [Shahid
 Buttar](https://www.eff.org/about/staff/shahid-buttar) from the
 [Electronic Frontier Foundation](https://www.eff.org/) will co-host a

--- a/content/meetings/2016-06-25.md
+++ b/content/meetings/2016-06-25.md
@@ -12,7 +12,7 @@ author = "ChicagoLUG"
 
 Our June meeting is set for Saturday, June 25th, starting at 2:00pm, and we'll
 be meeting at Pumping Station: One.  We will take time to learn about Qubes OS,
-a relatively new, security-focused GNU/Linux distribution. Freddy Martinez will
+a relatively new, security-focused Linux distribution. Freddy Martinez will
 discuss some of what makes it unique, as well as how it can be used in
 practice. Embedded Linux developer Drew Fustini will also share some of what he
 learned during the recent Linux Foundation, "Open Internet of Things and
@@ -21,7 +21,7 @@ Embedded Linux Conference," in San Diego.
 
 ### Qubes OS in Practice - Freddy Martinez
 
-Qubes OS is a GNU/Linux distribution with a unique take on security. Qubes
+Qubes OS is a Linux distribution with a unique take on security. Qubes
 provides *security through compartimentalization*, separating your computing
 actitivies into distinct, VM-managed computing environments.
 

--- a/content/meetings/2017-06-17.md
+++ b/content/meetings/2017-06-17.md
@@ -23,7 +23,7 @@ single-node OpenShift cluster inside a virtual machine. With Minishift you can
 try out OpenShift or develop with it, day-to-day, on your local machine.
 
 Bring whatever latop  you want because you can run Minishift on Windows, Mac OS,
-and even GNU/Linux operating systems. Minishift uses libmachine for provisioning
+and even Linux operating systems. Minishift uses libmachine for provisioning
 virtual machines, and OpenShift Origin for running the cluster.
 
 Sten Turpin of Red Hat will provide a walk-through demo of getting OpenShift


### PR DESCRIPTION
Change Chicago GNU/Linux User Group to Chicago Linux User Group
Change references to GNU/Linux to Linux
Retain usage of GNU when referencing projects like GNU MediaGoblin and GNU Guix